### PR TITLE
Timestamp

### DIFF
--- a/pyflightdata/common.py
+++ b/pyflightdata/common.py
@@ -22,6 +22,7 @@
 
 import json
 import sys
+import time
 
 from bs4 import BeautifulSoup
 from jsonpath_rw import parse
@@ -85,6 +86,10 @@ class ProcessorMixin(object):
                 'Referer': 'https://www.flightradar24.com'
             }
             result = FlightMixin.session.get(url, headers=headers)
+            if result.status_code != 200:
+                print("HTML code {0} - Retry in 10 seconds...".format(result.status_code))
+                time.sleep(10)
+                result = FlightMixin.session.get(url, headers=headers)
         except:
             return None
         return result.content if result.status_code == 200 else None

--- a/pyflightdata/common_fr24.py
+++ b/pyflightdata/common_fr24.py
@@ -24,7 +24,7 @@ from .common import ProcessorMixin
 from .json_helper import fltr
 
 ROOT = 'http://www.flightradar24.com'
-REG_BASE = 'https://api.flightradar24.com/common/v1/flight/list.json?query={0}&fetchBy=reg&page={2}&limit={3}&token={1}'
+REG_BASE = 'https://api.flightradar24.com/common/v1/flight/list.json?query={0}&fetchBy=reg&page={2}&limit={3}&token={1}&timestamp={4}'
 FLT_BASE = 'https://api.flightradar24.com/common/v1/flight/list.json?query={0}&fetchBy=flight&page={2}&limit={3}&token={1}'
 AIRPORT_BASE = 'http://www.flightradar24.com/data/airports/{0}'
 AIRPORT_DATA_BASE = 'https://api.flightradar24.com/common/v1/airport.json?code={0}&page={2}&limit={3}&token={1}'
@@ -40,6 +40,8 @@ LOGIN_URL = 'https://www.flightradar24.com/user/login'
 class FR24(ProcessorMixin):
 
     FILTER_JSON_KEYS = ['hex', 'id', 'logo', 'row', 'icon']
+
+    timestamp = ""
 
     # airport stats
 
@@ -110,6 +112,9 @@ class FR24(ProcessorMixin):
 
     def process_raw_flight_data(self, data, by_tail=False):
         # TODO check later if we need to parse this data - for now return full set
+        l = len(data)
+        self.timestamp = ""
+        if l > 0: self.timestamp = data[l-1]['time']['other']['updated']
         return data
 
     def get_data(self, url, by_tail=False):

--- a/pyflightdata/flightdata.py
+++ b/pyflightdata/flightdata.py
@@ -104,11 +104,11 @@ class FlightData(FlightMixin):
             f=FlightData()
             #optional login
             f.login(myemail,mypassword)
-            f.get_history_by_flight_number('VT-ANL')
-            f.get_history_by_flight_number('VT-ANL',page=1,limit=10)
+            f.get_history_by_tail_number('VT-ANL')
+            f.get_history_by_tail_number('VT-ANL',page=1,limit=10)
 
         """
-        url = REG_BASE.format(tail_number, str(self.AUTH_TOKEN), page, limit)
+        url = REG_BASE.format(tail_number, str(self.AUTH_TOKEN), page, limit, self._fr24.timestamp)
         return self._fr24.get_data(url, True)
 
     def get_countries(self):


### PR DESCRIPTION
To get the results from page > 1, a parameter `timestamp` is used by the FR24 server.

For the page 1:
`https://api.flightradar24.com/common/v1/flight/list.json?query={0}&fetchBy=reg&page={2}&limit={3}&token={1}&timestamp=`

For page > 1:
`https://api.flightradar24.com/common/v1/flight/list.json?query={0}&fetchBy=reg&page={2}&limit={3}&token={1}&timestamp={4}`

The value {4} has to be taken from the last entry of the previous page under ['time']['other']['updated'].

The 2nd hack adds a timeout when consecutive requests are sent to quickly. FR24 server responds time to time with an HTML code 402 or 400. 